### PR TITLE
Cleanups and add pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  build-latest:
+    name: Build and test latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Bootstrap
+        run: |
+          sudo apt-get install python3-setuptools
+      - name: mkdir build
+        run: mkdir build
+      - name: cmake ..
+        run: |
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+      - name: make
+        run: |
+          cd build
+          make
+      - name: ctest .
+        run: |
+          cd build
+          ctest -VV .
+
+  build-latest-clang:
+    name: Build and test latest clang
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Bootstrap
+        run: |
+          sudo apt-get install clang
+      - name: mkdir build
+        run: mkdir build
+      - name: cmake ..
+        run: |
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" ..
+      - name: make
+        run: |
+          cd build
+          make
+      - name: ctest .
+        run: |
+          cd build
+          ctest -VV .
+
+  build-1604:
+    name: Build and test 16.04
+    runs-on:  ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: Bootstrap
+        run: |
+          sudo apt-get install python3-setuptools
+      - name: mkdir build
+        run: mkdir build
+      - name: cmake ..
+        run: |
+          cd build
+          cmake  -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+      - name: make
+        run: |
+          cd build
+          make
+      - name: ctest .
+        run: |
+          cd build
+          ctest -VV .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: cmake ..
         run: |
           cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" ..
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCBOR_BUILD_FUZZ_TEST=off  -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" ..
       - name: make
         run: |
           cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ target_compile_features(cbor INTERFACE cxx_relaxed_constexpr)
 list(APPEND CBOR_EXPORTS cbor)
 
 
+option(CBOR_BUILD_FUZZ_TEST "Build the fuzztester, only has effect when build with clang." ON)
+
 # testing
 include(CTest)
 if(BUILD_TESTING)

--- a/include/cbor/pod.h
+++ b/include/cbor/pod.h
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <typeinfo>
 #include "cbor.h"
 #include "exceptions.h"
 #include "traits.h"

--- a/include/cbor/pod.h
+++ b/include/cbor/pod.h
@@ -211,7 +211,7 @@ struct read_adapter_helper
     const ReadAdapter& reader = *static_cast<const ReadAdapter*>(this);
     if (!isArray())
     {
-      std::uint8_t peeked;
+      std::uint8_t peeked{ 0 };
       reader.peek(peeked);
       CBOR_TYPE_ERROR("Parsed major type " + std::to_string(peeked) + " is different then expected type 0b100");
       return false;
@@ -224,7 +224,7 @@ struct read_adapter_helper
     const ReadAdapter& reader = *static_cast<const ReadAdapter*>(this);
     if (!isMap())
     {
-      std::uint8_t peeked;
+      std::uint8_t peeked{ 0 };
       reader.peek(peeked);
       CBOR_TYPE_ERROR("Parsed major type " + std::to_string(peeked) + " is different then expected type 0b100");
       return false;
@@ -235,7 +235,7 @@ struct read_adapter_helper
   result expectArray(const std::size_t N)
   {
     ReadAdapter& reader = *static_cast<ReadAdapter*>(this);
-    std::uint8_t first_byte;
+    std::uint8_t first_byte{ 0 };
     std::uint64_t length = 0;
     result res = deserializeItem(first_byte, length, reader);
     if (length != N)

--- a/include/cbor/stl.h
+++ b/include/cbor/stl.h
@@ -680,14 +680,14 @@ struct traits<trait_families::std_array_family, ArrayType>
   static result serializer(const std::array<InType, N>& d, Data& data)
   {
     // Let the c style array handle this one.
-    const auto& z = reinterpret_cast<const InType(&)[N]>(d);
+    const auto& z = type_cast<const InType(&)[N]>(d);
     return to_cbor(z, data);
   }
   template <typename InType, typename Data, size_t N>
   static result deserializer(std::array<InType, N>& d, Data& data)
   {
     // Let the c style array handle this one.
-    auto& z = reinterpret_cast<InType(&)[N]>(d);
+    auto& z = type_cast<InType(&)[N]>(d);
     return from_cbor(z, data);
   }
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(test_shortfloat PRIVATE cbor)
 target_compile_options(test_shortfloat PRIVATE ${CBOR_COMPILE_OPTIONS})
 add_test(shortfloat test_shortfloat)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CBOR_BUILD_FUZZ_TEST)
   set(FUZZ_CORPUS_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/fuzz_corpus/)
   add_custom_target(fuzz_corpus_init ${CMAKE_CURRENT_SOURCE_DIR}/generate_fuzz_corpus.py ${CMAKE_CURRENT_SOURCE_DIR} ${FUZZ_CORPUS_LOCATION})
   

--- a/test/shortfloat.cpp
+++ b/test/shortfloat.cpp
@@ -154,10 +154,18 @@ struct Table
   }
 };
 
+union float_uint32
+{
+  float f;
+  std::uint32_t i;
+};
+
 std::uint16_t encode(const float f_in)
 {
   static const auto& t = Table::getTables();
-  const std::uint32_t& f = *reinterpret_cast<const std::uint32_t*>(&f_in);
+  float_uint32 converter;
+  converter.f = f_in;
+  const std::uint32_t f = converter.i;
   return t.basetable[(f >> 23) & 0x1ff] + ((f & 0x007fffff) >> t.shifttable[(f >> 23) & 0x1ff]);
 }
 
@@ -165,7 +173,9 @@ float decode(const std::uint16_t h)
 {
   static const auto& t = Table::getTables();
   std::uint32_t z = t.mantissatable[t.offsettable[h >> 10] + (h & 0x3ff)] + t.exponenttable[h >> 10];
-  return *reinterpret_cast<const float*>(&z);
+  float_uint32 converter;
+  converter.i = z;
+  return converter.f;
 }
 
 }  //  namespace shortfloat

--- a/test/test_cbor_serializer.cpp
+++ b/test/test_cbor_serializer.cpp
@@ -41,6 +41,8 @@
 
 void test_stl()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
+
   // test tuple
   {
     std::tuple<unsigned int, unsigned int> input{ 1, 2 };
@@ -132,6 +134,7 @@ void test_stl()
 
 void test_array()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   // Serializing into and from array:
   {
     unsigned int input{ 2 };
@@ -221,6 +224,7 @@ cbor::result from_cbor(Bar& b, cbor::detail::read_adapter<Data...>& data)
 
 void test_adl()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   {
     foo::Bar input{ 2 };
     Data expected = { 0x02 };
@@ -250,6 +254,7 @@ void test_adl()
 
 void test_pod()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   tester<std::uint8_t>(50, { 0x18, 0x32 });
   tester<std::int8_t>(-50, { 0x38, 0x31 });
   tester<std::uint16_t>(50, { 0x18, 0x32 });
@@ -290,6 +295,7 @@ std::size_t to_cbor(const Buz& b, cbor::cbor_object& data)
  */
 void test_into_object()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   {
     cbor::cbor_object cbor_representation;
     unsigned int input{ 2 };
@@ -452,6 +458,7 @@ cbor::result from_cbor(Buz& b, Data& data)
 
 void test_compound_type()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   const bool print_compare = false;
   {
     compound_type::Bar input{ 2, 3 };
@@ -482,6 +489,7 @@ void test_compound_type()
       test(output[2].x, 7u, print_compare);
     }
   }
+
   {
     std::vector<compound_type::Buz> input = { compound_type::Buz{ 2, 5 }, compound_type::Buz{ 3, 6 },
                                               compound_type::Buz{ 4, 7 } };
@@ -522,6 +530,7 @@ void test_compound_type()
 
 void test_result_operators()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   cbor::result success1 = 5;
   cbor::result success2 = 5;
   std::cout << "success1: " << success1 << std::endl;
@@ -546,12 +555,11 @@ void test_result_operators()
   test(assign_false.success, false);
   std::cout << "assign_false: " << assign_false << std::endl;
 
-  test(bool{ assign_false }, false);
+  test(static_cast<bool>(assign_false), false);
 
   cbor::result assign_true = true;
   std::cout << "assign_true: " << assign_true << std::endl;
-
-  test(bool{ assign_true }, true);
+  test(static_cast<bool>(assign_true), true);
 
   cbor::result assign_one = 1;
   std::cout << "assign_one: " << assign_one << std::endl;
@@ -588,6 +596,7 @@ void test_result_operators()
 
 void test_appendix_a()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   // https://tools.ietf.org/html/rfc7049#appendix-A
   test_appendix_A_decode<std::uint32_t>("00", 0, true);
   test_appendix_A_decode<std::uint32_t>("01", 1, true);
@@ -683,6 +692,7 @@ void test_appendix_a()
 
 void test_exceptions()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   const bool no_print = false;
 
   expect_error<cbor::buffer_error>([]() {
@@ -731,6 +741,7 @@ void test_exceptions()
 
 void test_recursion()
 {
+  std::cout << "Test " << __FUNCTION__ << " " << __LINE__ << std::endl;
   const bool no_print = false;
 
   const uint8_t indefinite_array = 0b10011111;

--- a/test/test_shortfloat.cpp
+++ b/test/test_shortfloat.cpp
@@ -82,7 +82,7 @@ void test_half_precision_float()
     float h_to_f_rfc = rfc_decode(reinterpret_cast<const unsigned char*>(&half));
 
     // Own implementation must concur with shortfloat table implementation, which seems de-facto standard.
-    test(*reinterpret_cast<const std::uint32_t*>(&h_to_f_table), *reinterpret_cast<const std::uint32_t*>(&h_to_f_cbor),
+    test(cbor::type_cast<const std::uint32_t>(h_to_f_table), cbor::type_cast<const std::uint32_t>(h_to_f_cbor),
          print_off);
 
     // rfc decode doesn't do fraction of nans
@@ -92,7 +92,7 @@ void test_half_precision_float()
     }
     else
     {
-      test(*reinterpret_cast<const std::uint32_t*>(&h_to_f_table), *reinterpret_cast<const std::uint32_t*>(&h_to_f_rfc),
+      test(cbor::type_cast<const std::uint32_t>(h_to_f_table), cbor::type_cast<const std::uint32_t>(h_to_f_rfc),
            print_off);
     }
 
@@ -113,7 +113,7 @@ void test_complete_conversion_correctness()
   for (std::size_t i = 0; i < (1UL << 32); i++)
   {
     std::uint32_t float_as_i = i;
-    const float f = *reinterpret_cast<const float*>(&float_as_i);
+    const float f = cbor::type_cast<const float>(float_as_i);
     std::uint16_t f_to_h_table = shortfloat::encode(f);
     std::uint16_t f_to_h_cbor = FPH::encode<handle_out_of_bounds>(f);
     test(f_to_h_table, f_to_h_cbor, print_off);


### PR DESCRIPTION
In this PR:
- Add a pipeline that:
  - Compile on 16.04 with gcc 5.4
  - Compile on latest with gcc
  - Compile on latest with clang.

Fix the 'type pruned pointer violates strict aliasing rules' warnings, which resulted in errors on the unit tests as those are compiled with `-Werror`.