### PR TITLE
Signed conversion correctness.

### DIFF
--- a/include/cbor/util.h
+++ b/include/cbor/util.h
@@ -66,21 +66,19 @@ inline std::uint64_t fixEndianness(const std::uint64_t in)
 
 namespace detail
 {
-
-template < typename T>
-struct  RefWrapper
+template <typename T>
+struct RefWrapper
 {
   const T& value;
 };
 
 template <typename In, typename Out>
-union Converter
-{
-    RefWrapper<In> in;
-    RefWrapper<Out> out;
+union Converter {
+  RefWrapper<In> in;
+  RefWrapper<Out> out;
 };
 
-}
+}  // namespace detail
 
 /**
  * @brief Interpret memory at in into a different type.
@@ -92,7 +90,7 @@ union Converter
 template <typename Out, typename In>
 const Out& type_cast(const In& in)
 {
-  return detail::Converter<In, Out>{{in}}.out.value;  // don't ask about the curly braces.
+  return detail::Converter<In, Out>{ { in } }.out.value;  // don't ask about the curly braces.
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,11 @@
 
-set(CBOR_COMPILE_OPTIONS "-Werror;-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic;")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CLANG_ONLY_COMPILE_FLAGS "-Wconversion;")
+  message(STATUS "Compiler is clang, adding options: ${CLANG_ONLY_COMPILE_FLAGS}")
+  # disable mismatched tags until https://github.com/nlohmann/json/issues/1401
+  set(CLANG_ONLY_COMPILE_FLAGS "${CLANG_ONLY_COMPILE_FLAGS};-Wno-mismatched-tags")
+endif()
+set(CBOR_COMPILE_OPTIONS "-Werror;-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic;${CLANG_ONLY_COMPILE_FLAGS}")
 
 add_executable(test_cbor_serializer test_cbor_serializer.cpp)
 target_link_libraries(test_cbor_serializer PRIVATE cbor)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,6 @@
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CLANG_ONLY_COMPILE_FLAGS "-Wconversion;")
   message(STATUS "Compiler is clang, adding options: ${CLANG_ONLY_COMPILE_FLAGS}")
-  # disable mismatched tags until https://github.com/nlohmann/json/issues/1401
-  set(CLANG_ONLY_COMPILE_FLAGS "${CLANG_ONLY_COMPILE_FLAGS};-Wno-mismatched-tags")
 endif()
 set(CBOR_COMPILE_OPTIONS "-Werror;-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic;${CLANG_ONLY_COMPILE_FLAGS}")
 

--- a/test/test.h
+++ b/test/test.h
@@ -118,7 +118,7 @@ Data hexToData(std::string s)
     thing.resize(2);
     thing[0] = s[i * 2];
     thing[1] = s[i * 2 + 1];
-    res.push_back(std::strtoll(thing.data(), nullptr, 16));
+    res.push_back(static_cast<Data::value_type>(std::strtoll(thing.data(), nullptr, 16)));
   }
   return res;
 }

--- a/test/test_cbor_serializer.cpp
+++ b/test/test_cbor_serializer.cpp
@@ -569,7 +569,7 @@ void test_result_operators()
   std::cout << "assign_zero: " << assign_zero << std::endl;
   test(assign_zero.success, true);
   test(assign_zero.length, 0u);
-  std::uint32_t x = assign_one;
+  std::uint32_t x = static_cast<std::uint32_t>(assign_one);
   std::cout << "x: " << x << std::endl;
   test(x, 1u);
 

--- a/test/test_shortfloat.cpp
+++ b/test/test_shortfloat.cpp
@@ -64,7 +64,7 @@ void test_half_precision_float()
 {
   using FPH = cbor::detail::trait_floating_point_helper<std::uint16_t>;
   test(FPH::encode(0.0), 0x0000);
-  test(FPH::encode(std::pow(2, -24)), 0x0001);
+  test(FPH::encode(static_cast<float>(std::pow(2, -24))), 0x0001);
   test(FPH::encode(-0.0), 0x8000);
   test(FPH::encode(1.0), 0x3c00);
   test(FPH::encode(-2.0), 0xc000);
@@ -76,10 +76,10 @@ void test_half_precision_float()
   for (std::size_t i = 0; i < (1 << 16); i++)
   {
     // Test decodes.
-    std::uint16_t half = i;
+    std::uint16_t half = static_cast<std::uint16_t>(i);
     float h_to_f_table = shortfloat::decode(half);
     float h_to_f_cbor = FPH::decode(half);
-    float h_to_f_rfc = rfc_decode(reinterpret_cast<const unsigned char*>(&half));
+    float h_to_f_rfc = static_cast<float>(rfc_decode(reinterpret_cast<const unsigned char*>(&half)));
 
     // Own implementation must concur with shortfloat table implementation, which seems de-facto standard.
     test(cbor::type_cast<const std::uint32_t>(h_to_f_table), cbor::type_cast<const std::uint32_t>(h_to_f_cbor),
@@ -112,7 +112,7 @@ void test_complete_conversion_correctness()
   // Check if the table and own implementation concur on all possible conversions.
   for (std::size_t i = 0; i < (1UL << 32); i++)
   {
-    std::uint32_t float_as_i = i;
+    std::uint32_t float_as_i = static_cast<std::uint32_t>(i);
     const float f = cbor::type_cast<const float>(float_as_i);
     std::uint16_t f_to_h_table = shortfloat::encode(f);
     std::uint16_t f_to_h_cbor = FPH::encode<handle_out_of_bounds>(f);
@@ -124,7 +124,7 @@ float get_random()
 {
   static std::default_random_engine e;
   static std::uniform_real_distribution<> dis(-65535, 65535);
-  return dis(e);
+  return static_cast<float>(dis(e));
 }
 void compare_speed()
 {


### PR DESCRIPTION
This fixes all the implicit conversion warnings that occured with `-Wconversions` that was being used in clang.

Also clang formatted everything after my changes.