### PR TITLE
Support stl pointers

### DIFF
--- a/include/cbor/pod.h
+++ b/include/cbor/pod.h
@@ -392,6 +392,16 @@ struct read_adapter_helper
     }
     return false;
   }
+
+  bool isNull() const
+  {
+    std::uint8_t v;
+    if (peek(v))
+    {
+      return v == ((0b111 << 5) | 22);
+    }
+    return false;
+  }
 };
 
 template <>

--- a/include/cbor/stl.h
+++ b/include/cbor/stl.h
@@ -579,8 +579,9 @@ template <typename PointedType>
 struct traits<std::shared_ptr<PointedType>>
 {
   using Type = std::shared_ptr<PointedType>;
+
   template <typename Data>
-  static result serializer(const std::shared_ptr<PointedType>& v, Data& data)
+  static result serializer(const Type& v, Data& data)
   {
     if (v == nullptr)
     {
@@ -597,13 +598,8 @@ struct traits<std::shared_ptr<PointedType>>
       v = nullptr;
       return data.advance(1);
     }
-    else
-    {
-      v = std::make_shared<PointedType>();
-      auto res = from_cbor(*v, data);
-      return res;
-    }
-    return false;
+    v = std::make_shared<PointedType>();
+    return from_cbor(*v, data);
   }
 };
 
@@ -614,8 +610,9 @@ template <typename PointedType>
 struct traits<std::unique_ptr<PointedType>>
 {
   using Type = std::unique_ptr<PointedType>;
+
   template <typename Data>
-  static result serializer(const std::unique_ptr<PointedType>& v, Data& data)
+  static result serializer(const Type& v, Data& data)
   {
     if (v == nullptr)
     {
@@ -632,13 +629,8 @@ struct traits<std::unique_ptr<PointedType>>
       v = nullptr;
       return data.advance(1);
     }
-    else
-    {
-      v = std::make_unique<PointedType>();
-      auto res = from_cbor(*v, data);
-      return res;
-    }
-    return false;
+    v = std::make_unique<PointedType>();
+    return from_cbor(*v, data);
   }
 };
 

--- a/include/cbor/stl.h
+++ b/include/cbor/stl.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <tuple>
 #include <vector>
+#include <memory>
 #include "cbor.h"
 #include "exceptions.h"
 #include "traits.h"
@@ -570,6 +571,79 @@ struct traits<std::map<KeyType, ValueType>>
     return res;
   }
 };
+
+
+
+/**
+ * Specialization for std::shared_ptr.
+ */
+template <typename PointedType>
+struct traits<std::shared_ptr<PointedType>>
+{
+  using Type = std::shared_ptr<PointedType>;
+  template <typename Data>
+  static result serializer(const std::shared_ptr<PointedType>& v, Data& data)
+  {
+    if (v == nullptr)
+    {
+      return to_cbor(nullptr, data);
+    }
+    return to_cbor(*v, data);
+  }
+
+  template <typename Data>
+  static result deserializer(Type& v, Data& data)
+  {
+    if (data.isNull())
+    {
+      v = nullptr;
+      return data.advance(1);
+    }
+    else
+    {
+      v = std::make_shared<PointedType>();
+      auto res = from_cbor(*v, data);
+      return res;
+    }
+    return false;
+  }
+};
+
+/**
+ * Specialization for std::unique_ptr.
+ */
+template <typename PointedType>
+struct traits<std::unique_ptr<PointedType>>
+{
+  using Type = std::unique_ptr<PointedType>;
+  template <typename Data>
+  static result serializer(const std::unique_ptr<PointedType>& v, Data& data)
+  {
+    if (v == nullptr)
+    {
+      return to_cbor(nullptr, data);
+    }
+    return to_cbor(*v, data);
+  }
+
+  template <typename Data>
+  static result deserializer(Type& v, Data& data)
+  {
+    if (data.isNull())
+    {
+      v = nullptr;
+      return data.advance(1);
+    }
+    else
+    {
+      v = std::make_unique<PointedType>();
+      auto res = from_cbor(*v, data);
+      return res;
+    }
+    return false;
+  }
+};
+
 
 /**
  * Specialization for cbor_object.

--- a/include/cbor/stl.h
+++ b/include/cbor/stl.h
@@ -33,9 +33,9 @@
 #include <iomanip>
 #include <limits>
 #include <map>
+#include <memory>
 #include <tuple>
 #include <vector>
-#include <memory>
 #include "cbor.h"
 #include "exceptions.h"
 #include "traits.h"
@@ -572,8 +572,6 @@ struct traits<std::map<KeyType, ValueType>>
   }
 };
 
-
-
 /**
  * Specialization for std::shared_ptr.
  */
@@ -643,7 +641,6 @@ struct traits<std::unique_ptr<PointedType>>
     return false;
   }
 };
-
 
 /**
  * Specialization for cbor_object.

--- a/test/test_cbor_serializer.cpp
+++ b/test/test_cbor_serializer.cpp
@@ -767,6 +767,62 @@ void test_recursion()
   });
 }
 
+
+void test_pointer_serialization()
+{
+  {
+    std::shared_ptr<int> input = std::make_shared<int>(2);
+    
+    Data expected = { 0x02 };
+    Data cbor_representation;
+    auto res = cbor::to_cbor(input, cbor_representation);
+    test_result(res, cbor_representation, expected);
+
+    std::shared_ptr<int> read_back;
+    cbor::from_cbor(read_back, cbor_representation);
+    test(*read_back, *input);
+  }
+  {
+    std::shared_ptr<int> input;
+    
+    Data expected = { ((0b111 << 5) | 22) };
+    Data cbor_representation;
+    auto res = cbor::to_cbor(input, cbor_representation);
+    test_result(res, cbor_representation, expected);
+
+    std::shared_ptr<int> read_back = std::make_shared<int>(1337);
+    cbor::from_cbor(read_back, cbor_representation);
+    test(read_back == nullptr, true);
+    test(input == nullptr, true);
+  }
+
+  {
+    std::unique_ptr<int> input = std::make_unique<int>(2);
+    
+    Data expected = { 0x02 };
+    Data cbor_representation;
+    auto res = cbor::to_cbor(input, cbor_representation);
+    test_result(res, cbor_representation, expected);
+
+    std::unique_ptr<int> read_back;
+    cbor::from_cbor(read_back, cbor_representation);
+    test(*read_back, *input);
+  }
+  {
+    std::unique_ptr<int> input;
+    
+    Data expected = { ((0b111 << 5) | 22) };
+    Data cbor_representation;
+    auto res = cbor::to_cbor(input, cbor_representation);
+    test_result(res, cbor_representation, expected);
+
+    std::unique_ptr<int> read_back = std::make_unique<int>(1337);
+    cbor::from_cbor(read_back, cbor_representation);
+    test(read_back == nullptr, true);
+    test(input == nullptr, true);
+  }
+}
+
 int main(int /* argc */, char** /* argv */)
 {
   test_pod();
@@ -779,6 +835,7 @@ int main(int /* argc */, char** /* argv */)
   test_appendix_a();
   test_exceptions();
   test_recursion();
+  test_pointer_serialization();
 
   if (failed)
   {

--- a/test/test_cbor_serializer.cpp
+++ b/test/test_cbor_serializer.cpp
@@ -767,12 +767,11 @@ void test_recursion()
   });
 }
 
-
 void test_pointer_serialization()
 {
   {
     std::shared_ptr<int> input = std::make_shared<int>(2);
-    
+
     Data expected = { 0x02 };
     Data cbor_representation;
     auto res = cbor::to_cbor(input, cbor_representation);
@@ -784,7 +783,7 @@ void test_pointer_serialization()
   }
   {
     std::shared_ptr<int> input;
-    
+
     Data expected = { ((0b111 << 5) | 22) };
     Data cbor_representation;
     auto res = cbor::to_cbor(input, cbor_representation);
@@ -798,7 +797,7 @@ void test_pointer_serialization()
 
   {
     std::unique_ptr<int> input = std::make_unique<int>(2);
-    
+
     Data expected = { 0x02 };
     Data cbor_representation;
     auto res = cbor::to_cbor(input, cbor_representation);
@@ -810,7 +809,7 @@ void test_pointer_serialization()
   }
   {
     std::unique_ptr<int> input;
-    
+
     Data expected = { ((0b111 << 5) | 22) };
     Data cbor_representation;
     auto res = cbor::to_cbor(input, cbor_representation);


### PR DESCRIPTION
This adds support in the trait system for `std::shared_ptr` and `std::unique_ptr`. If they are present in any data structure they are dereferenced and the data is serialized. If it is a nullptr this information is preserved by encoding a cbor `null`.

@jasonimercer, @efernandez

