### PR TITLE
Fixes and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Supported STL containers:
 - `std::array`: Handled as `d[N]`.
 - `std::string`: Handled as `const char*`. Deserialization supports 'indefinite' strings.
 
+Supported STL smart pointers:
+- `std::shared_ptr`: Serializes the dereferenced ponter. If a `nullptr` this serializes as cbor `null` type.
+- `std::unique_ptr`: Serializes the dereferenced ponter. If a `nullptr` this serializes as cbor `null` type.
+
 Supported CBOR types:
 - `map`, indefinite length supported for `std::map`.
 - `array`, indefinite length supported for `std::vector`.

--- a/include/cbor/pod.h
+++ b/include/cbor/pod.h
@@ -428,15 +428,15 @@ struct write_adapter<DataType*> : std::true_type, write_adapter_helper<write_ada
   {
   }
 
-  result resize(std::uint32_t value)
+  result resize(std::uint32_t resize_value)
   {
-    if (value > max_length)
+    if (resize_value > max_length)
     {
-      CBOR_BUFFER_ERROR("Resize failed: " + std::to_string(value) +
+      CBOR_BUFFER_ERROR("Resize failed: " + std::to_string(resize_value) +
                         " exceed max length: " + std::to_string(max_length));
       return false;
     }
-    used_size = value;
+    used_size = resize_value;
     return true;
   }
 
@@ -723,9 +723,9 @@ static result deserializeSignedInteger(Type& v, Data& data)
   std::uint64_t res;
   result advanced = deserializeItem(first, res, data);
   std::uint8_t read_major_type = first >> 5;
-  if (read_major_type == 0b000)
+  if (read_major_type == 0b000)  // positive integer
   {
-    if (res > std::numeric_limits<Type>::max())
+    if (res > static_cast<std::uint64_t>(std::numeric_limits<Type>::max()))
     {
       CBOR_TYPE_ERROR("Deserialized value" + std::to_string(res) + " does not fit in " + typeid(Type).name())
       return false;
@@ -736,7 +736,7 @@ static result deserializeSignedInteger(Type& v, Data& data)
       return advanced;
     }
   }
-  else if (read_major_type == 0b001)
+  else if (read_major_type == 0b001)  // negative integer
   {
     std::int64_t signedres = -(static_cast<std::int64_t>(res) + 1);
     if (signedres < std::numeric_limits<Type>::min())

--- a/include/cbor/stl.h
+++ b/include/cbor/stl.h
@@ -64,9 +64,9 @@ struct write_adapter<Data> : std::true_type, write_adapter_helper<write_adapter<
   }
   write_adapter<Data>(Data& d) : data{ d } {};
 
-  result resize(std::size_t value)
+  result resize(std::size_t resize_value)
   {
-    data.resize(value);
+    data.resize(resize_value);
     return true;
   }
   std::size_t size() const


### PR DESCRIPTION
In this PR:
- Update readme to include the `std::shared_ptr` and `std::unique_ptr` support added recently.
- Include fixes for compiler warnings present with gcc 9, which will ship with Eoan.

Warnings were discovered by @mikepurvis during preliminary work trying to compile on Eoan.

Tested using the `ubuntu/eoan64` image for vagrant, guest extensions don't work though, so no convenient shared folders.

@jasonimercer, @efernandez