### PR TITLE
Change has_trait mechanism.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Supported STL containers:
 - `std::string`: Handled as `const char*`. Deserialization supports 'indefinite' strings.
 
 Supported STL smart pointers:
-- `std::shared_ptr`: Serializes the dereferenced ponter. If a `nullptr` this serializes as cbor `null` type.
-- `std::unique_ptr`: Serializes the dereferenced ponter. If a `nullptr` this serializes as cbor `null` type.
+- `std::shared_ptr`: Serializes the dereferenced pointer. If a `nullptr` this serializes as cbor `null` type.
+- `std::unique_ptr`: Serializes the dereferenced pointer. If a `nullptr` this serializes as cbor `null` type.
 
 Supported CBOR types:
 - `map`, indefinite length supported for `std::map`.

--- a/include/cbor/traits.h
+++ b/include/cbor/traits.h
@@ -186,10 +186,33 @@ struct trait_dispatcher<T, 0>
   using Type = trait_selector<0, T>;
 };
 
-//
-// Some helpers to check whether a type is supported by our traits.
+/**
+ * @brief Struct with SFINEA to check whether a particular TypeToCheck could be instantiated.
+ * this is used to check whether a specialization exists. This makes use of the fact that a templated struct without a
+ * body like:
+ *      template <typename T, typename = void>
+ *      struct traits;
+ * does not allow sizeof() to be called on it.
+ */
+template <typename TypeToCheck>
+struct SizeofExists
+{
+private:
+  // Check whether sizeof(U) can compile, if it is the return type of test is true_type.
+  template <typename U>
+  static auto test(int) -> decltype((sizeof(U), std::true_type()));
+
+  // Otherwise we fall back to this and we return a false_type
+  template <typename>
+  static auto test(...) -> std::false_type;
+
+public:
+  static constexpr bool value = decltype(test<TypeToCheck>(0))::value;
+};
+
+// Helpers to check whether a type is supported by our traits.
 template <typename T>
-using has_trait = std::is_default_constructible<typename detail::trait_dispatcher<T>::Type::Trait>;
+using has_trait = SizeofExists<typename detail::trait_dispatcher<T>::Type::Trait>;
 
 }  // namespace detail
 }  // namespace cbor


### PR DESCRIPTION
@jasonimercer identified that the way I used to check whether a specialisation existed with `std::is_default_constructible` doesn't work in clang 9 when called on unspecialised structs.

```
n file included from /opt/compiler-explorer/gcc-9.2.0/lib/gcc/x86_64-linux-gnu/9.2.0/../../../../include/c++/9.2.0/bits/move.h:55:

/opt/compiler-explorer/gcc-9.2.0/lib/gcc/x86_64-linux-gnu/9.2.0/../../../../include/c++/9.2.0/type_traits:884:32: error: implicit instantiation of undefined template 'cbor::detail::traits<my_namespace::Buz, void>'

      : public __bool_constant<__is_constructible(_Tp, _Args...)>

                               ^

/opt/compiler-explorer/gcc-9.2.0/lib/gcc/x86_64-linux-gnu/9.2.0/../../../../include/c++/9.2.0/type_traits:890:14: note: in instantiation of template class 'std::is_constructible<cbor::detail::traits<my_namespace::Buz, void>>' requested here

    : public is_constructible<_Tp>::type

             ^
<source>:1603:58: note: in instantiation of template class 'std::is_default_constructible<cbor::detail::traits<my_namespace::Buz, void> >' requested here

template <typename T, typename... Data, std::enable_if_t<has_trait<T>::value, int> = 0>

                                                         ^
```

From https://stackoverflow.com/a/40822131, this fails because for `is_default_constructible` `T` needs to be a complete type;
```
N4140 § 20.10.4.3 [meta.unary.prop] / is_default_constructible row

T shall be a complete type, (possibly cv-qualified) void, or an array of unknown bound.
```

As a solution we introduce a struct that uses SFINEA and makes use of `sizeof(T)` to select the appropriate method. `sizeof(T)` does not compile if `T` is not specialised, so the fallback would be used.